### PR TITLE
Changed file extension to be .asm 

### DIFF
--- a/ftdetect/lc3.vim
+++ b/ftdetect/lc3.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile *.lc3 set filetype=lc3
+au BufRead,BufNewFile *.asm set filetype=lc3


### PR DESCRIPTION
LC3 Assembly files use .asm, so the plugin needs to use the correct extension. 